### PR TITLE
Dockerfile for build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM archlinux/base
+
+RUN set -e; \
+    set -x; \
+    pacman -Sy --noconfirm arm-none-eabi-binutils \
+                           arm-none-eabi-gcc \
+                           arm-none-eabi-newlib \
+                           doxygen \
+                           graphviz \
+                           make \
+                           python; \
+    pacman -Scc --noconfirm


### PR DESCRIPTION
Install dependencies required to build documentation and firmware of the Deadlock Reader